### PR TITLE
Return original.contentLength() for RenderedResources

### DIFF
--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedResource.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedResource.java
@@ -54,7 +54,7 @@ public class AssociatedResource implements HttpResource {
     @Override
     public long contentLength() throws IOException {
         Long contentLength = (Long) BeanUtils.getFieldWithAnnotation(entity, ContentLength.class);
-        if (contentLength == null) {
+        if (contentLength == null || original instanceof RenderedResource) {
             contentLength = original.contentLength();
         }
         return contentLength;


### PR DESCRIPTION
Hey Paul,

Thanks for the project.

While working with your spring-docs app, I noticed that rendition images were getting truncated. To fix this, I updated AssociatedResource to get the contentLength() from the RenderedResource object for rendition requests. It looks like that is what you intended.

Regards,

Lauren