### PR TITLE
Version attribute names need to match VersionInfo

### DIFF
--- a/spring-versions-jpa/src/main/asciidoc/jpaversions-rest.adoc
+++ b/spring-versions-jpa/src/main/asciidoc/jpaversions-rest.adoc
@@ -36,7 +36,7 @@ endpoint will be available at the `/{repository}/{id}/version` URI.
 ====
 [source, sh]
 ----
-  curl -X PUT http://localhost:8080/docs/1234/version -d '{"version_number": "1.1", "version_label": "a minor change"}'
+  curl -X PUT http://localhost:8080/docs/1234/version -d '{"number": "1.1", "label": "a minor change"}'
 ----
 ====
 


### PR DESCRIPTION
Hey Paul,

I updated the ~/version asscidoc to use the property names associated with VerionInfo object. The version was created but the values were not set if I didn't use these names.

Regards, 

Lauren