### PR TITLE
Rename the autoconfigured AmazonS3 bean

### DIFF
--- a/spring-content-autoconfigure/src/main/java/internal/org/springframework/content/s3/boot/autoconfigure/S3ContentAutoConfiguration.java
+++ b/spring-content-autoconfigure/src/main/java/internal/org/springframework/content/s3/boot/autoconfigure/S3ContentAutoConfiguration.java
@@ -25,8 +25,8 @@ public class S3ContentAutoConfiguration {
 	public static class EnableS3StoresConfig {}
 
 	@Bean
-	@ConditionalOnMissingBean
-	public AmazonS3 s3Client() {
+	@ConditionalOnMissingBean()
+	public AmazonS3 amazonS3() {
 		AmazonS3 s3Client = new AmazonS3Client();
 		return s3Client;
 	}


### PR DESCRIPTION
- to avoid conflict with spring cloud aws messaging

Fixes #622