### PR TITLE
Use the managed version of the h2 dependency

### DIFF
--- a/spring-content-jpa/pom.xml
+++ b/spring-content-jpa/pom.xml
@@ -71,7 +71,6 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.0.206</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Rather than override it with exactly the same version!