### PR TITLE
Put lombok in the provided scope

### DIFF
--- a/spring-content-azure-storage/pom.xml
+++ b/spring-content-azure-storage/pom.xml
@@ -34,6 +34,11 @@
 		  <artifactId>azure-storage-file-share</artifactId>
 		  <version>12.11.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- Test Dependencies -->
 		<dependency>

--- a/spring-content-cmis/pom.xml
+++ b/spring-content-cmis/pom.xml
@@ -68,6 +68,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- CMIS -->

--- a/spring-content-commons/pom.xml
+++ b/spring-content-commons/pom.xml
@@ -25,6 +25,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 		    <groupId>commons-lang</groupId>

--- a/spring-content-elasticsearch/pom.xml
+++ b/spring-content-elasticsearch/pom.xml
@@ -26,6 +26,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Test Dependencies -->

--- a/spring-content-fs/pom.xml
+++ b/spring-content-fs/pom.xml
@@ -70,6 +70,11 @@
 			<version>3.12.4</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jpa</artifactId>

--- a/spring-content-gcs/pom.xml
+++ b/spring-content-gcs/pom.xml
@@ -73,6 +73,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/spring-content-jpa/pom.xml
+++ b/spring-content-jpa/pom.xml
@@ -64,6 +64,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
  			<scope>test</scope>

--- a/spring-content-mongo/pom.xml
+++ b/spring-content-mongo/pom.xml
@@ -41,6 +41,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
 			<version>${powermock.version}</version>

--- a/spring-content-rest/pom.xml
+++ b/spring-content-rest/pom.xml
@@ -72,6 +72,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/spring-content-s3/pom.xml
+++ b/spring-content-s3/pom.xml
@@ -64,6 +64,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
The lombok annotation processor should be placed in the provided scope,
so its dependency is not propagated to projects that depend on
spring-content.

This matches with the installation instructions: https://projectlombok.org/setup/maven

Fixes #768
