### PR TITLE
Optimize byte range requests to S3 Storage

### DIFF
--- a/spring-content-commons/src/main/java/org/springframework/content/commons/io/RangeableResource.java
+++ b/spring-content-commons/src/main/java/org/springframework/content/commons/io/RangeableResource.java
@@ -1,0 +1,12 @@
+package org.springframework.content.commons.io;
+
+public interface RangeableResource {
+
+    /**
+     * An optional aspect for Resources that wish to be given Range specifications so that they
+     * can prepare InputStream appropriately
+     *
+     * @param range the range
+     */
+    void setRange(String range);
+}

--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/AssociativeStoreContentService.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/AssociativeStoreContentService.java
@@ -17,6 +17,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.content.commons.io.RangeableResource;
 import org.springframework.content.commons.mappingcontext.ContentProperty;
 import org.springframework.content.commons.property.PropertyPath;
 import org.springframework.content.commons.repository.AssociativeStore;
@@ -120,6 +121,10 @@ public class AssociativeStoreContentService implements ContentService {
                     response.setStatus(HttpStatus.NOT_FOUND.value());
                     return;
                 }
+            }
+
+            if (resource instanceof RangeableResource) {
+                this.configureResourceForByteRangeRequest((RangeableResource)resource, headers);
             }
 
             request.setAttribute("SPRING_CONTENT_RESOURCE", resource);
@@ -343,5 +348,11 @@ public class AssociativeStoreContentService implements ContentService {
             return true;
         }
         return false;
+    }
+
+    private void configureResourceForByteRangeRequest(RangeableResource resource, HttpHeaders headers) {
+        if (headers.containsKey(HttpHeaders.RANGE)) {
+            resource.setRange(headers.getFirst(HttpHeaders.RANGE));
+        }
     }
 }

--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/ContentStoreContentService.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/ContentStoreContentService.java
@@ -19,6 +19,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.content.commons.io.RangeableResource;
 import org.springframework.content.commons.mappingcontext.ContentProperty;
 import org.springframework.content.commons.property.PropertyPath;
 import org.springframework.content.commons.repository.ContentStore;
@@ -124,6 +125,10 @@ public class ContentStoreContentService implements ContentService {
                 }
             }
 
+            if (resource instanceof RangeableResource) {
+                this.configureResourceForByteRangeRequest((RangeableResource)resource, headers);
+            }
+
             request.setAttribute("SPRING_CONTENT_RESOURCE", resource);
             request.setAttribute("SPRING_CONTENT_CONTENTTYPE", producedResourceType);
         } catch (Exception e) {
@@ -193,16 +198,6 @@ public class ContentStoreContentService implements ContentService {
         } finally {
             cleanup(contentArg);
         }
-    }
-
-    private int indexOfContentArg(Class<?>[] paramTypes) {
-        for (int i=0; i < paramTypes.length; i++) {
-            if (InputStream.class.equals(paramTypes[i]) || Resource.class.equals(paramTypes[i])) {
-                return i;
-            }
-        }
-
-        return 0;
     }
 
     @Override
@@ -290,6 +285,22 @@ public class ContentStoreContentService implements ContentService {
             }
         }
         return true;
+    }
+
+    private void configureResourceForByteRangeRequest(RangeableResource resource, HttpHeaders headers) {
+        if (headers.containsKey(HttpHeaders.RANGE)) {
+            resource.setRange(headers.getFirst(HttpHeaders.RANGE));
+        }
+    }
+
+    private int indexOfContentArg(Class<?>[] paramTypes) {
+        for (int i=0; i < paramTypes.length; i++) {
+            if (InputStream.class.equals(paramTypes[i]) || Resource.class.equals(paramTypes[i])) {
+                return i;
+            }
+        }
+
+        return 0;
     }
 
     public static StoreExportedMethodsMap getExportedMethodsFor(Class<?> storeInterfaceClass) {

--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/StoreContentService.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/StoreContentService.java
@@ -14,6 +14,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.content.commons.io.DeletableResource;
+import org.springframework.content.commons.io.RangeableResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.http.HttpHeaders;
@@ -66,6 +67,10 @@ public class StoreContentService implements ContentService {
                 }
             }
 
+            if (resource instanceof RangeableResource) {
+                this.configureResourceForByteRangeRequest((RangeableResource)resource, headers);
+            }
+
             request.setAttribute("SPRING_CONTENT_RESOURCE", resource);
             request.setAttribute("SPRING_CONTENT_CONTENTTYPE", producedResourceType);
         } catch (Exception e) {
@@ -113,6 +118,12 @@ public class StoreContentService implements ContentService {
             catch (IOException e) {
                 e.printStackTrace();
             }
+        }
+    }
+
+    private void configureResourceForByteRangeRequest(RangeableResource resource, HttpHeaders headers) {
+        if (headers.containsKey(HttpHeaders.RANGE)) {
+            resource.setRange(headers.getFirst(HttpHeaders.RANGE));
         }
     }
 }

--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedStoreResource.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedStoreResource.java
@@ -1,9 +1,10 @@
 package internal.org.springframework.content.rest.io;
 
+import org.springframework.content.commons.io.RangeableResource;
 import org.springframework.content.commons.mappingcontext.ContentProperty;
 import org.springframework.core.io.WritableResource;
 
-public interface AssociatedStoreResource<S> extends WritableResource, StoreResource {
+public interface AssociatedStoreResource<S> extends WritableResource, StoreResource, RangeableResource {
 
     S getAssociation();
 

--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedStoreResourceImpl.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedStoreResourceImpl.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 import javax.persistence.Version;
 
 import org.springframework.content.commons.io.DeletableResource;
+import org.springframework.content.commons.io.RangeableResource;
 import org.springframework.content.commons.mappingcontext.ContentProperty;
 import org.springframework.content.commons.property.PropertyPath;
 import org.springframework.content.commons.renditions.Renderable;
@@ -272,5 +273,12 @@ public class AssociatedStoreResourceImpl<S> implements HttpResource, AssociatedS
     public void delete()
             throws IOException {
         ((DeletableResource)original).delete();
+    }
+
+    @Override
+    public void setRange(String range) {
+        if (original instanceof RangeableResource) {
+            ((RangeableResource)original).setRange(range);
+        }
     }
 }

--- a/spring-content-s3/src/main/java/internal/org/springframework/content/s3/io/S3StoreResource.java
+++ b/spring-content-s3/src/main/java/internal/org/springframework/content/s3/io/S3StoreResource.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URL;
 
 import org.springframework.content.commons.io.DeletableResource;
+import org.springframework.content.commons.io.RangeableResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.util.Assert;
@@ -15,7 +16,7 @@ import org.springframework.util.Assert;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
-public class S3StoreResource implements WritableResource, DeletableResource {
+public class S3StoreResource implements WritableResource, DeletableResource, RangeableResource {
 
 	private S3Client client;
 	private Resource delegate;
@@ -115,4 +116,9 @@ public class S3StoreResource implements WritableResource, DeletableResource {
 	public OutputStream getOutputStream() throws IOException {
 		return ((WritableResource) delegate).getOutputStream();
 	}
+
+    @Override
+    public void setRange(String range) {
+        ((RangeableResource)delegate).setRange(range);
+    }
 }

--- a/spring-content-s3/src/main/java/internal/org/springframework/content/s3/io/SimpleStorageResource.java
+++ b/spring-content-s3/src/main/java/internal/org/springframework/content/s3/io/SimpleStorageResource.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
 
+import org.springframework.content.commons.io.RangeableResource;
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.core.task.TaskExecutor;
@@ -50,7 +51,7 @@ import software.amazon.awssdk.utils.BinaryUtils;
  * @author Alain Sahli
  * @since 1.0
  */
-public class SimpleStorageResource extends AbstractResource implements WritableResource {
+public class SimpleStorageResource extends AbstractResource implements WritableResource, RangeableResource {
 
     private final String bucketName;
 
@@ -63,6 +64,8 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
     private final TaskExecutor taskExecutor;
 
     private volatile HeadObjectResponse objectMetadata;
+
+    private String range;
 
     public SimpleStorageResource(S3Client amazonS3, String bucketName, String objectName,
             TaskExecutor taskExecutor) {
@@ -94,11 +97,20 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
     }
 
     @Override
+    public void setRange(String range) {
+        this.range = range;
+    }
+
+    @Override
     public InputStream getInputStream() throws IOException {
         GetObjectRequest.Builder getObjectRequestBuilder = GetObjectRequest.builder()
                 .bucket(this.bucketName).key(this.objectName);
         if (this.versionId != null) {
             getObjectRequestBuilder.versionId(this.versionId);
+        }
+        if (this.range != null) {
+            getObjectRequestBuilder.range(range);
+            return new PartialContentInputStream(this.amazonS3.getObject(getObjectRequestBuilder.build()));
         }
         return this.amazonS3.getObject(getObjectRequestBuilder.build());
     }
@@ -397,4 +409,90 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
 
     }
 
+    /**
+     * Create a new partial content input stream wrapper around the given delegate.
+     *
+     * The delegate is expected to be a "prepared" input stream onto a byte-range.  Reading the
+     * input stream return the byte-range only.
+     */
+    public static class PartialContentInputStream extends InputStream {
+
+        private InputStream delegate;
+
+        public PartialContentInputStream(InputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        /**
+         * As this is a wrapper on a prepared input stream if the consumer asks us to skip
+         * just reply that we have.
+         */
+        @Override
+        public long skip(long n)
+                throws IOException {
+            return n;
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
+
+        @Override
+        public int read(byte[] b)
+                throws IOException {
+            return delegate.read(b);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return delegate.equals(obj);
+        }
+
+        @Override
+        public int read()
+                throws IOException {
+
+            return delegate.read();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len)
+                throws IOException {
+            return delegate.read(b, off, len);
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+
+        @Override
+        public int available()
+                throws IOException {
+            return delegate.available();
+        }
+
+        @Override
+        public void close()
+                throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public void mark(int readlimit) {
+            delegate.mark(readlimit);
+        }
+
+        @Override
+        public void reset()
+                throws IOException {
+            delegate.reset();
+        }
+
+        @Override
+        public boolean markSupported() {
+            return delegate.markSupported();
+        }
+    }
 }


### PR DESCRIPTION
Only download the requested byte range and not the entire content.  