### PR TITLE
fix: class walker should support empty path lookups for entities with a single content property of correlated attributes

### DIFF
--- a/spring-content-commons/src/main/java/org/springframework/content/commons/mappingcontext/ContentPropertyBuilderVisitor.java
+++ b/spring-content-commons/src/main/java/org/springframework/content/commons/mappingcontext/ContentPropertyBuilderVisitor.java
@@ -80,7 +80,7 @@ public class ContentPropertyBuilderVisitor {
 
     public boolean visitClassEnd(Class<?> klazz) {
 
-        if (looseMode && properties.size() > 1) {
+        if (looseMode && properties.size() >= 1) {
 
             LOGGER.trace(String.format("Loose mode enabled. Collapsing properties for %s", klazz.getCanonicalName()));
 

--- a/spring-content-commons/src/test/java/org/springframework/content/commons/mappingcontext/ClassWalkerTest.java
+++ b/spring-content-commons/src/test/java/org/springframework/content/commons/mappingcontext/ClassWalkerTest.java
@@ -97,6 +97,30 @@ public class ClassWalkerTest {
             });
         });
 
+        Context("given a class with correlated attributes", () -> {
+            It("should return two content properties", () -> {
+                ContentPropertyBuilderVisitor visitor = new ContentPropertyBuilderVisitor("/", ".", new ContentPropertyBuilderVisitor.CanonicalName());
+                ClassWalker walker = new ClassWalker(CorrelatedAttrClass.class);
+                walker.accept(visitor);
+
+                ContentProperty expectedProperty = new ContentProperty();
+                expectedProperty.setContentPropertyPath("content");
+                expectedProperty.setContentIdPropertyPath("contentId");
+                expectedProperty.setContentLengthPropertyPath("contentLen");
+                expectedProperty.setMimeTypePropertyPath("contentMimeType");
+                expectedProperty.setOriginalFileNamePropertyPath("contentOriginalFileName");
+                assertThat(visitor.getProperties(), hasEntry("", expectedProperty));
+
+                ContentProperty expectedProperty2 = new ContentProperty();
+                expectedProperty2.setContentPropertyPath("content");
+                expectedProperty2.setContentIdPropertyPath("contentId");
+                expectedProperty2.setContentLengthPropertyPath("contentLen");
+                expectedProperty2.setMimeTypePropertyPath("contentMimeType");
+                expectedProperty2.setOriginalFileNamePropertyPath("contentOriginalFileName");
+                assertThat(visitor.getProperties(), hasEntry("content", expectedProperty2));
+            });
+        });
+
         Context("given a class with a child with uncorrelated attributes", () -> {
             It("should return two content properties", () -> {
                 ContentPropertyBuilderVisitor visitor = new ContentPropertyBuilderVisitor("/", ".", new ContentPropertyBuilderVisitor.CanonicalName());
@@ -197,6 +221,16 @@ public class ClassWalkerTest {
         private @ContentLength Long len;
         private @MimeType String mimeType;
         private @OriginalFileName String originalFileName;
+        private String title;
+    }
+
+    public static class CorrelatedAttrClass {
+        private @Id @GeneratedValue Long id;
+        private String name;
+        private @ContentId UUID contentId;
+        private @ContentLength Long contentLen;
+        private @MimeType String contentMimeType;
+        private @OriginalFileName String contentOriginalFileName;
         private String title;
     }
 

--- a/spring-content-rest/src/test/java/internal/org/springframework/content/rest/support/TestEntity9.java
+++ b/spring-content-rest/src/test/java/internal/org/springframework/content/rest/support/TestEntity9.java
@@ -1,0 +1,25 @@
+package internal.org.springframework.content.rest.support;
+
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.springframework.content.commons.annotations.ContentId;
+import org.springframework.content.commons.annotations.ContentLength;
+import org.springframework.content.commons.annotations.MimeType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class TestEntity9 {
+    public @Id @GeneratedValue Long id;
+    public String name;
+    public @ContentId UUID contentId;
+    public @ContentLength Long contentLen;
+    public @MimeType String contentMimeType;
+}

--- a/spring-content-rest/src/test/java/internal/org/springframework/content/rest/support/TestEntity9Repository.java
+++ b/spring-content-rest/src/test/java/internal/org/springframework/content/rest/support/TestEntity9Repository.java
@@ -1,0 +1,5 @@
+package internal.org.springframework.content.rest.support;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface TestEntity9Repository extends CrudRepository<TestEntity9, Long> {}

--- a/spring-content-rest/src/test/java/internal/org/springframework/content/rest/support/TestEntity9Store.java
+++ b/spring-content-rest/src/test/java/internal/org/springframework/content/rest/support/TestEntity9Store.java
@@ -1,0 +1,8 @@
+package internal.org.springframework.content.rest.support;
+
+import java.util.UUID;
+
+import org.springframework.content.fs.store.FilesystemContentStore;
+
+public interface TestEntity9Store extends FilesystemContentStore<TestEntity9, UUID> {}
+


### PR DESCRIPTION

- fixes #931