### PR TITLE
fix: use multi-part file size to set content length property

### DIFF
--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/ContentStoreContentService.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/ContentStoreContentService.java
@@ -178,9 +178,10 @@ public class ContentStoreContentService implements ContentService {
         Object contentArg = convertContentArg(source, methodToUse.getParameterTypes()[indexOfContentArg(methodToUse.getParameterTypes())]);
         argsList.add(contentArg);
         if (methodToUse.getParameters().length > 3 && methodToUse.getParameters()[3].getType().equals(long.class)) {
-            long len = -1L;
+            long len = source.contentLength();
+            
             // if available use the original content length
-            if (headers.containsKey(HttpHeaders.CONTENT_LENGTH)) {
+            if (len <= 0L && headers.containsKey(HttpHeaders.CONTENT_LENGTH)) {
                 len = headers.getContentLength();
             }
             argsList.add(len);

--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/ContentStoreContentService.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/contentservice/ContentStoreContentService.java
@@ -178,10 +178,9 @@ public class ContentStoreContentService implements ContentService {
         Object contentArg = convertContentArg(source, methodToUse.getParameterTypes()[indexOfContentArg(methodToUse.getParameterTypes())]);
         argsList.add(contentArg);
         if (methodToUse.getParameters().length > 3 && methodToUse.getParameters()[3].getType().equals(long.class)) {
-            long len = source.contentLength();
-            
+            long len = -1L;
             // if available use the original content length
-            if (len <= 0L && headers.containsKey(HttpHeaders.CONTENT_LENGTH)) {
+            if (headers.containsKey(HttpHeaders.CONTENT_LENGTH)) {
                 len = headers.getContentLength();
             }
             argsList.add(len);

--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/controllers/StoreRestController.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/controllers/StoreRestController.java
@@ -125,6 +125,8 @@ public class StoreRestController implements InitializingBean  {
 
         ContentService contentService = contentServiceFactory.getContentService(storeResource);
 
+        headers.setContentLength(multiPart.getSize());
+
         handleMultipart(request, response, headers,
                 contentService,
                 multiPart.getResource(),
@@ -144,6 +146,8 @@ public class StoreRestController implements InitializingBean  {
 
         ContentService contentService = contentServiceFactory.getContentService(storeResource);
 
+        headers.setContentLength(multiPart.getSize());
+        
         handleMultipart(request, response, headers,
                 contentService,
                 new InputStreamResource(multiPart.getInputStream(), multiPart.getOriginalFilename()),

--- a/spring-content-rest/src/test/java/it/internal/org/springframework/content/rest/controllers/StoreRestEndpointsIT.java
+++ b/spring-content-rest/src/test/java/it/internal/org/springframework/content/rest/controllers/StoreRestEndpointsIT.java
@@ -33,6 +33,7 @@ import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.Context;
 import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.Describe;
 import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.FIt;
 import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.It;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -94,6 +95,7 @@ public class StoreRestEndpointsIT {
 						assertThat(IOUtils.contentEquals(
 								new ByteArrayInputStream("New multi-part content".getBytes()),
 								r.getInputStream()), is(true));
+						assertThat(r.contentLength(), equalTo(Long.valueOf(content.length())));
 					});
 				});
 				Context("given a DELETE request to that path", () -> {
@@ -159,6 +161,7 @@ public class StoreRestEndpointsIT {
 								new ByteArrayInputStream(
 										"New multi-part content".getBytes()),
 								r.getInputStream()), is(true));
+						assertThat(r.contentLength(), equalTo(Long.valueOf(content.length())));
 					});
 				});
 				It("should delete the resource", () -> {
@@ -234,6 +237,7 @@ public class StoreRestEndpointsIT {
 								new ByteArrayInputStream(
 										"New multi-part content".getBytes()),
 								r.getInputStream()), is(true));
+						assertThat(r.contentLength(), equalTo(Long.valueOf(content.length())));
 					});
 				});
 				It("should delete the resource", () -> {


### PR DESCRIPTION
This PR fixes a problem with using HTTP request content length when uploading files via multi-part form data PUT request. 

The content length should be set using multipart/form-data file size instead of HTTP request content length, so that content can be downloaded later with the correct file length in the HTTP response.