### PR TITLE
Fixes two NPE conditions in DefaultEntityResolver return statement

### DIFF
--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/controllers/resolvers/DefaultEntityResolver.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/controllers/resolvers/DefaultEntityResolver.java
@@ -23,6 +23,8 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpUpgradeHandler;
 import jakarta.servlet.http.Part;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.content.commons.mappingcontext.ContentProperty;
 import org.springframework.content.commons.mappingcontext.MappingContext;
 import org.springframework.content.commons.property.PropertyPath;
@@ -39,6 +41,7 @@ import org.springframework.data.repository.support.Repositories;
 import org.springframework.data.repository.support.RepositoryInvoker;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
@@ -55,7 +58,7 @@ import internal.org.springframework.content.rest.utils.RepositoryUtils;
 import internal.org.springframework.content.rest.utils.StoreUtils;
 
 public class DefaultEntityResolver implements EntityResolver {
-    private static final  Logger logger = org.slf4j.LoggerFactory.getLogger(DefaultEntityResolver.class);
+    private static final Logger logger = LoggerFactory.getLogger(DefaultEntityResolver.class);
     private static boolean ROOT_RESOURCE_INFORMATION_CLASS_PRESENT = false;
 
     static {
@@ -172,15 +175,17 @@ public class DefaultEntityResolver implements EntityResolver {
                 invoker = resolveRootResourceInformation(info, repository, id, new ModelAndViewContainer(), new FakeWebBinderFactory());
                 if (invoker != null) {
                     domainObj = invoker.invokeFindById(id);
+                } else {
+                    logger.warn("Could not resolve RootResourceInformation");
                 }
             } catch (ConverterNotFoundException e) {
-                logger.debug("resolveRootResourceInformation failed with root resource information class present");
+                logger.debug("invoking Repository findById(id) method failed");
                 domainObj = findOneByReflection(repositories, domainObjClass, id);
             } catch (AccessDeniedException ace) {
-                logger.debug("invoking Repository findById(id) method threw AccessDeniedException with root resource information class present");
+                logger.debug("invoking Repository findById(id) method threw AccessDeniedException");
                 throw ace;
             } catch (Exception e) {
-                logger.error("invoking findById(id)failed  with root resource information class present", e.getCause());
+                logger.error("invoking Repository findById(id) method threw exception", e.getCause());
             }
         } else {
 

--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/controllers/resolvers/DefaultEntityResolver.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/controllers/resolvers/DefaultEntityResolver.java
@@ -55,7 +55,7 @@ import internal.org.springframework.content.rest.utils.RepositoryUtils;
 import internal.org.springframework.content.rest.utils.StoreUtils;
 
 public class DefaultEntityResolver implements EntityResolver {
-
+    private static final  Logger logger = org.slf4j.LoggerFactory.getLogger(DefaultEntityResolver.class);
     private static boolean ROOT_RESOURCE_INFORMATION_CLASS_PRESENT = false;
 
     static {
@@ -163,7 +163,7 @@ public class DefaultEntityResolver implements EntityResolver {
     public Object findOne(Repositories repositories, StoreInfo info, Class<?> domainObjClass, String repository, Serializable id)
             throws HttpRequestMethodNotSupportedException {
 
-        Optional<Object> domainObj = null;
+        Optional<Object> domainObj = Optional.empty();
 
         if (ROOT_RESOURCE_INFORMATION_CLASS_PRESENT) {
 
@@ -174,11 +174,13 @@ public class DefaultEntityResolver implements EntityResolver {
                     domainObj = invoker.invokeFindById(id);
                 }
             } catch (ConverterNotFoundException e) {
-
+                logger.debug("resolveRootResourceInformation failed with root resource information class present");
                 domainObj = findOneByReflection(repositories, domainObjClass, id);
+            } catch (AccessDeniedException ace) {
+                logger.debug("invoking Repository findById(id) method threw AccessDeniedException with root resource information class present");
+                throw ace;
             } catch (Exception e) {
-
-                e.printStackTrace();
+                logger.error("invoking findById(id)failed  with root resource information class present", e.getCause());
             }
         } else {
 


### PR DESCRIPTION
Fixes: 
1. initializes the Optional as empty, not as null object.
2. added [optional] exception handler for AccessDeniedException for throwing it. 
3. added [optional] (slf4j) logging 


First change fixes the two NullPointerExeception cases in method last return statement.   
a) when `invoker == null`  
b) AccessDeniedException or any Expection  other than ConverterNotFoundException is thrown.  


2.&3. are not necessary, but I think improve the code. 
