### PR TITLE
fix: ensure storage factory beans don't rely on constructor injection

### DIFF
--- a/spring-content-azure-storage/src/main/java/internal/org/springframework/content/azure/config/AzureStorageFactoryBean.java
+++ b/spring-content-azure-storage/src/main/java/internal/org/springframework/content/azure/config/AzureStorageFactoryBean.java
@@ -20,15 +20,14 @@ import internal.org.springframework.content.azure.store.DefaultAzureStorageImpl;
 @SuppressWarnings("rawtypes")
 public class AzureStorageFactoryBean extends AbstractStoreFactoryBean {
 
-    @Autowired
     private ApplicationContext context;
 
-	@Autowired
 	private BlobServiceClientBuilder clientBuilder;
     private BlobServiceClient client;
 
-	@Autowired
 	private PlacementService storePlacementService;
+
+	private AzureStorageProtocolResolver resolver;
 
 //	@Autowired(required=false)
 //	private MultiTenantS3ClientProvider s3Provider = null;
@@ -39,15 +38,30 @@ public class AzureStorageFactoryBean extends AbstractStoreFactoryBean {
 	@Autowired(required=false)
 	private LockingAndVersioningProxyFactory versioning;
 
-	@Autowired
-	private AzureStorageProtocolResolver resolver;
+
+	public AzureStorageFactoryBean(Class<? extends Store> storeInterface) {
+		super(storeInterface);
+	}
 
 	@Autowired
-	public AzureStorageFactoryBean(Class<? extends Store> storeInterface, ApplicationContext context, BlobServiceClientBuilder client, PlacementService storePlacementService) {
-		super(storeInterface);
-	    this.context = context;
-		this.client = client.buildClient();
+	public void setContext(ApplicationContext context) {
+		this.context = context;
+	}
+
+	@Autowired
+	public void setClientBuilder(BlobServiceClientBuilder clientBuilder) {
+		this.clientBuilder = clientBuilder;
+		this.client = clientBuilder.buildClient();
+	}
+
+	@Autowired
+	public void setStorePlacementService(PlacementService storePlacementService) {
 		this.storePlacementService = storePlacementService;
+	}
+
+	@Autowired
+	public void setResolver(AzureStorageProtocolResolver resolver) {
+		this.resolver = resolver;
 	}
 
 	@Override

--- a/spring-content-gcs/src/main/java/internal/org/springframework/content/gcs/config/GCPStorageFactoryBean.java
+++ b/spring-content-gcs/src/main/java/internal/org/springframework/content/gcs/config/GCPStorageFactoryBean.java
@@ -20,16 +20,13 @@ import internal.org.springframework.content.gcs.store.DefaultGCPStorageImpl;
 @SuppressWarnings("rawtypes")
 public class GCPStorageFactoryBean extends AbstractStoreFactoryBean {
 
-//	public static final S3ObjectIdResolver<Serializable> DEFAULT_S3OBJECTID_RESOLVER_STORE = S3ObjectIdResolver.createDefaultS3ObjectIdHelper();
-
-    @Autowired
     private ApplicationContext context;
 
-	@Autowired
 	private Storage client;
 
-	@Autowired
 	private PlacementService s3StorePlacementService;
+
+	private GoogleStorageProtocolResolver resolver;
 
 //	@Autowired(required=false)
 //	private MultiTenantS3ClientProvider s3Provider = null;
@@ -40,18 +37,34 @@ public class GCPStorageFactoryBean extends AbstractStoreFactoryBean {
 	@Autowired(required=false)
 	private LockingAndVersioningProxyFactory versioning;
 
-	@Autowired
-	private GoogleStorageProtocolResolver resolver;
-
 	@Value("${spring.content.gcp.storage.bucket:#{environment.GCP_STORAGE_BUCKET}}")
 	private String bucket;
 
-	@Autowired
-	public GCPStorageFactoryBean(Class<? extends Store> storeInterface, ApplicationContext context, Storage client, PlacementService s3StorePlacementService) {
+	public GCPStorageFactoryBean(Class<? extends Store> storeInterface) {
 		super(storeInterface);
 	    this.context = context;
 		this.client = client;
 		this.s3StorePlacementService = s3StorePlacementService;
+	}
+
+	@Autowired
+	public void setContext(ApplicationContext context) {
+		this.context = context;
+	}
+
+	@Autowired
+	public void setClient(Storage client) {
+		this.client = client;
+	}
+
+	@Autowired
+	public void setS3StorePlacementService(PlacementService s3StorePlacementService) {
+		this.s3StorePlacementService = s3StorePlacementService;
+	}
+
+	@Autowired
+	public void setResolver(GoogleStorageProtocolResolver resolver) {
+		this.resolver = resolver;
 	}
 
 	@Override

--- a/spring-content-s3/src/main/java/internal/org/springframework/content/s3/config/S3StoreFactoryBean.java
+++ b/spring-content-s3/src/main/java/internal/org/springframework/content/s3/config/S3StoreFactoryBean.java
@@ -25,19 +25,14 @@ import software.amazon.awssdk.services.s3.S3Client;
 @SuppressWarnings("rawtypes")
 public class S3StoreFactoryBean extends AbstractStoreFactoryBean {
 
-//	public static final S3ObjectIdResolver<Serializable> DEFAULT_S3OBJECTID_RESOLVER_STORE = S3ObjectIdResolver.createDefaultS3ObjectIdHelper();
-
-    @Autowired
     private ApplicationContext context;
 
-	@Autowired
 	private S3Client client;
+
+	private PlacementService s3StorePlacementService;
 
     @Autowired(required=false)
     private S3AsyncClient asyncClient;
-
-	@Autowired
-	private PlacementService s3StorePlacementService;
 
 	@Autowired(required=false)
 	private MultiTenantS3ClientProvider s3Provider = null;
@@ -51,12 +46,22 @@ public class S3StoreFactoryBean extends AbstractStoreFactoryBean {
 	@Value("${spring.content.s3.bucket:#{environment.AWS_BUCKET}}")
 	private String bucket;
 
+	public S3StoreFactoryBean(Class<? extends Store> storeInterface) {
+		super(storeInterface);
+	}
 
 	@Autowired
-	public S3StoreFactoryBean(Class<? extends Store> storeInterface, ApplicationContext context, S3Client client, PlacementService s3StorePlacementService) {
-		super(storeInterface);
-	    this.context = context;
+	public void setContext(ApplicationContext context) {
+		this.context = context;
+	}
+
+	@Autowired
+	public void setClient(S3Client client) {
 		this.client = client;
+	}
+
+	@Autowired
+	public void setS3StorePlacementService(PlacementService s3StorePlacementService) {
 		this.s3StorePlacementService = s3StorePlacementService;
 	}
 

--- a/spring-content-s3/src/test/java/internal/org/springframework/content/s3/config/S3StoreFactoryBeanTest.java
+++ b/spring-content-s3/src/test/java/internal/org/springframework/content/s3/config/S3StoreFactoryBeanTest.java
@@ -44,7 +44,10 @@ public class S3StoreFactoryBeanTest {
 				context.registerBean("amazonS3", S3Client.class, () -> client);
 				context.refresh();
 
-				factory = new S3StoreFactoryBean(S3StoreFactoryBeanTest.TestStore.class, context, client, placer);
+				factory = new S3StoreFactoryBean(S3StoreFactoryBeanTest.TestStore.class/*, context, client, placer*/);
+				factory.setContext(context);
+				factory.setClient(client);
+				factory.setS3StorePlacementService(placer);
 			});
 			Context("#getStore", () -> {
 				BeforeEach(() -> {


### PR DESCRIPTION
With the way that storage beans are created in Spring Content 3 constructor injection can fail when used inside `@DataJpaTest`s.

Fixes #1444