### PR TITLE
fix(setup): do not add junit as compile dependency

### DIFF
--- a/spring-content-azure-storage/pom.xml
+++ b/spring-content-azure-storage/pom.xml
@@ -44,6 +44,7 @@
 		<dependency>
 		  <groupId>junit</groupId>
 		  <artifactId>junit</artifactId>
+		  <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.github.paulcwarren</groupId>

--- a/spring-content-gcs/pom.xml
+++ b/spring-content-gcs/pom.xml
@@ -34,6 +34,7 @@
 		<dependency>
 		  <groupId>junit</groupId>
 		  <artifactId>junit</artifactId>
+		  <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.github.paulcwarren</groupId>


### PR DESCRIPTION
Add test scope to `junit `dependencies.

Closes #1541