### PR TITLE
Optimize memory usage during upload of smaller files to amazon S3

### DIFF
--- a/spring-content-s3/src/main/java/internal/org/springframework/content/s3/io/SimpleStorageResource.java
+++ b/spring-content-s3/src/main/java/internal/org/springframework/content/s3/io/SimpleStorageResource.java
@@ -24,6 +24,7 @@ import org.springframework.core.io.WritableResource;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.core.task.support.ExecutorServiceAdapter;
 
+import org.springframework.util.FastByteArrayOutputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
@@ -242,8 +243,7 @@ public class SimpleStorageResource extends AbstractResource implements WritableR
         private final CompletionService<CompletedPart> completionService;
 
         @SuppressWarnings("FieldMayBeFinal")
-        private ByteArrayOutputStream currentOutputStream = new ByteArrayOutputStream(
-                BUFFER_SIZE);
+        private FastByteArrayOutputStream currentOutputStream = new FastByteArrayOutputStream();
 
         private int partNumberCounter = 1;
 


### PR DESCRIPTION
The class `internal.org.springframework.content.s3.io.SimpleStorageResource.SimpleStorageOutputStream` seems to be pre-allocating 5MB for uploads to amazon S3. When used by several concurrent users to upload smaller files (~200KB), this eager-allocation seems to be using more memory than necessary. This results in OOM errors when the number of concurrent users is sufficiently high. 

Changing the implementation to use

`ByteArrayOutputStream currentOutputStream = new ByteArrayOutputStream()`

instead of 

`ByteArrayOutputStream currentOutputStream = new ByteArrayOutputStream(BUFFER_SIZE)`

should help, but if used in a system which usually uploads large files, this might introduce a penalty for growing the buffer from the initial 32 bytes pre-allocated by ByteArrayOutputStream.

Using `org.springframework.util.FastByteArrayOutputStream` from spring-core seems like a good sweet-spot for both use-cases, i.e it pre-allocates 256 bytes and subsequent requests for writing more data result in creation of new buffers instead of growing the existing buffer, hence avoiding the extra step of copying data. An added potential advantage (I've not tested this) is that FastByteArrayOutputStream may be able to work even if the heap is fragmented but ByteArrayOutputStream may need a contiguous block of memory for the full buffer.

This PR changes the implementation to use FastByteArrayOutputStream with a pre-allocated buffer of 256 bytes instead of a ByteArrayOutputStream with a pre-allocated buffer of 5MB. 
