### PR TITLE
Correct content-disposition response header to be of type 'attachment'

### DIFF
--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedStoreResourceImpl.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedStoreResourceImpl.java
@@ -193,8 +193,9 @@ public class AssociatedStoreResourceImpl<S> implements HttpResource, AssociatedS
         // Modified to show download
         Object originalFileName = this.getContentProperty().getOriginalFileName(this.getAssociation());
         if (originalFileName != null && StringUtils.hasText(originalFileName.toString())) {
-            ContentDisposition.Builder builder = ContentDisposition.builder("form-data").name( "attachment").filename((String)originalFileName, Charset.defaultCharset());
-            headers.setContentDisposition(builder.build());
+            headers.setContentDisposition(ContentDisposition.attachment().filename((String) originalFileName, Charset.defaultCharset()).build());
+        } else {
+            headers.setContentDisposition(ContentDisposition.attachment().build());
         }
         return headers;
     }


### PR DESCRIPTION
Having Content-Disposition set to 'form-data' is only valid in multipart form submissions (in the request), never in a response.
In a response, the content-disposition should only be set to either 'attachment' or 'inline': https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#as_a_response_header_for_the_main_body

Given the `name="attachment"` part of the current (incorrect) content-disposition header, I believe the goal was to have `content-disposition: attachment` set as header.

When there is no filename available for the content, `Content-Disposition: attachment` should be set as well to always force a download of the content, otherwise a browser would fall back to the default (which is `inline`).

Using `Content-Disposition: inline` is problematic for resources created by untrusted users: HTML pages can contain scripts that would run in the context of the API, so care should be taken to always set `Content-Disposition: attachment`.

