### PR TITLE
fix: now uses utf8 when setting content-dispostion filename

### DIFF
--- a/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedStoreResourceImpl.java
+++ b/spring-content-rest/src/main/java/internal/org/springframework/content/rest/io/AssociatedStoreResourceImpl.java
@@ -11,6 +11,7 @@ import java.net.URL;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
 import java.util.stream.Stream;
@@ -193,7 +194,7 @@ public class AssociatedStoreResourceImpl<S> implements HttpResource, AssociatedS
         // Modified to show download
         Object originalFileName = this.getContentProperty().getOriginalFileName(this.getAssociation());
         if (originalFileName != null && StringUtils.hasText(originalFileName.toString())) {
-            headers.setContentDisposition(ContentDisposition.attachment().filename((String) originalFileName, Charset.defaultCharset()).build());
+            headers.setContentDisposition(ContentDisposition.attachment().filename((String) originalFileName, StandardCharsets.UTF_8).build());
         } else {
             headers.setContentDisposition(ContentDisposition.attachment().build());
         }


### PR DESCRIPTION
windows defaults to windows-1252 which is not compliant with rfc5987 that governs how to encode header fields

Fixes #1556