### PR TITLE
fix: add a copyBufferSize bean that allows configuration of the buffer size used by the jpa store copyLarge operation

### DIFF
--- a/spring-content-autoconfigure/src/main/java/internal/org/springframework/content/jpa/boot/autoconfigure/ContentJpaProperties.java
+++ b/spring-content-autoconfigure/src/main/java/internal/org/springframework/content/jpa/boot/autoconfigure/ContentJpaProperties.java
@@ -10,6 +10,8 @@ public class ContentJpaProperties {
 
 	private final ContentJpaProperties.Initializer initializer = new ContentJpaProperties.Initializer();
 
+	private int copyBufferSize = 4096;
+
 	public Initializer getInitializer() {
 		return initializer;
 	}
@@ -28,5 +30,13 @@ public class ContentJpaProperties {
 		public void setInitializeSchema(DatabaseInitializationMode initializeSchema) {
 			this.initializeSchema = initializeSchema;
 		}
+	}
+
+	public void setCopyBufferSize(int copyBufferSize) {
+		this.copyBufferSize = copyBufferSize;
+	}
+
+	public int getCopyBufferSize() {
+		return this.copyBufferSize;
 	}
 }

--- a/spring-content-autoconfigure/src/main/java/internal/org/springframework/content/jpa/boot/autoconfigure/JpaContentAutoConfiguration.java
+++ b/spring-content-autoconfigure/src/main/java/internal/org/springframework/content/jpa/boot/autoconfigure/JpaContentAutoConfiguration.java
@@ -52,6 +52,12 @@ public class JpaContentAutoConfiguration {
 		return new ContentJpaDatabaseInitializer(dataSource, properties);
 	}
 
+	@Bean
+	@ConditionalOnMissingBean
+	public Integer copyBufferSize() {
+		return properties.getCopyBufferSize();
+	}
+
 	@Configuration
 	@ConditionalOnMissingBean(JpaStoreFactoryBean.class)
 	@Import({ JpaContentAutoConfigureRegistrar.class, JpaStoreConfiguration.class })

--- a/spring-content-autoconfigure/src/test/java/org/springframework/content/jpa/boot/autoconfigure/ContentJpaAutoConfigurationTest.java
+++ b/spring-content-autoconfigure/src/test/java/org/springframework/content/jpa/boot/autoconfigure/ContentJpaAutoConfigurationTest.java
@@ -58,12 +58,14 @@ public class ContentJpaAutoConfigurationTest {
 				contextRunner.withUserConfiguration(TestConfig.class).run((context) -> {
 					Assertions.assertThat(context).hasSingleBean(TestEntityContentRepository.class);
 					Assertions.assertThat(context).hasSingleBean(ContentJpaDatabaseInitializer.class);
+					Assertions.assertThat(context).hasBean("copyBufferSize");
 				});
 			});
 			Context("when a custom bean configuration is used", () -> {
 				It("should use the supplied custom bean", () -> {
 					contextRunner.withUserConfiguration(CustomBeanConfig.class).run((context) -> {
 						Assertions.assertThat(context).getBean(ContentJpaDatabaseInitializer.class).isEqualTo(initializer);
+						Assertions.assertThat(context).getBean("copyBufferSize").isEqualTo(16192);
 					});
 				});
 			});
@@ -73,8 +75,8 @@ public class ContentJpaAutoConfigurationTest {
 						Assertions.assertThat(context).hasSingleBean(TestEntityContentRepository.class);
 						Assertions.assertThat(context).hasSingleBean(ContentJpaProperties.class);
 						Assertions.assertThat(context).hasSingleBean(ContentJpaDatabaseInitializer.class);
+						Assertions.assertThat(context).hasBean("copyBufferSize");
 					});
-
 				});
 			});
 		});
@@ -123,6 +125,11 @@ public class ContentJpaAutoConfigurationTest {
 		public ContentJpaDatabaseInitializer initializer() {
 			return initializer;
 		}
+
+		@Bean
+		public Integer copyBufferSize() {
+			return 16192;
+		}
 	}
 
 	@SpringBootApplication(exclude={JpaVersionsAutoConfiguration.class,SolrAutoConfiguration.class, SolrExtensionAutoConfiguration.class, S3ContentAutoConfiguration.class})
@@ -133,7 +140,7 @@ public class ContentJpaAutoConfigurationTest {
 	@SpringBootApplication(exclude={JpaVersionsAutoConfiguration.class,SolrAutoConfiguration.class, SolrExtensionAutoConfiguration.class, S3ContentAutoConfiguration.class})
 	@Import(JpaTestConfig.class)
 	@PropertySource("classpath:/custom-jpa.properties")
-	public static class CustomPropertiesConfig extends TestConfig {
+	public static class CustomPropertiesConfig {
 	}
 
 	public interface TestEntityRepository extends JpaRepository<TestEntity, Long> {}

--- a/spring-content-autoconfigure/src/test/resources/default.properties
+++ b/spring-content-autoconfigure/src/test/resources/default.properties
@@ -1,1 +1,2 @@
 spring.jmx.enabled=false
+spring.content.jpa.copy-buffer-size: 8096

--- a/spring-content-jpa/src/main/java/internal/org/springframework/content/jpa/config/JpaStoreFactoryBean.java
+++ b/spring-content-jpa/src/main/java/internal/org/springframework/content/jpa/config/JpaStoreFactoryBean.java
@@ -27,6 +27,9 @@ public class JpaStoreFactoryBean extends AbstractStoreFactoryBean {
 	@Autowired(required=false)
 	private PlatformTransactionManager ptm;
 
+	@Autowired(required=false)
+	private Integer copyBufferSize = 4096;
+
 	protected JpaStoreFactoryBean(Class<? extends Store> storeInterface) {
 		super(storeInterface);
 	}
@@ -34,7 +37,7 @@ public class JpaStoreFactoryBean extends AbstractStoreFactoryBean {
 	@Override
 	protected Object getContentStoreImpl() {
 		Assert.notNull(blobResourceLoader, "blobResourceLoader cannot be null");
-		return new DefaultJpaStoreImpl(blobResourceLoader, mappingContext);
+		return new DefaultJpaStoreImpl(blobResourceLoader, mappingContext, copyBufferSize);
 	}
 
 	@Override

--- a/spring-content-jpa/src/main/java/internal/org/springframework/content/jpa/store/DefaultJpaStoreImpl.java
+++ b/spring-content-jpa/src/main/java/internal/org/springframework/content/jpa/store/DefaultJpaStoreImpl.java
@@ -47,16 +47,19 @@ public class DefaultJpaStoreImpl<S, SID extends Serializable>
 
 	private static Log logger = LogFactory.getLog(DefaultJpaStoreImpl.class);
 
-	private ResourceLoader loader;
+    private ResourceLoader loader;
 
     private MappingContext mappingContext/* = new MappingContext("/", ".")*/;
 
-	public DefaultJpaStoreImpl(ResourceLoader blobResourceLoader, MappingContext mappingContext) {
+    private int copyBufferSize = 4096;
+
+	public DefaultJpaStoreImpl(ResourceLoader blobResourceLoader, MappingContext mappingContext, int copyBufferSize) {
 		this.loader = blobResourceLoader;
 		this.mappingContext = mappingContext;
 		if (this.mappingContext == null) {
 		    this.mappingContext = new MappingContext("/", ".");
 		}
+        this.copyBufferSize = copyBufferSize;
 	}
 
 	@Override
@@ -212,7 +215,7 @@ public class DefaultJpaStoreImpl<S, SID extends Serializable>
 		try {
 			if (resource instanceof WritableResource) {
 				os = ((WritableResource) resource).getOutputStream();
-				contentLen = IOUtils.copyLarge(content, os);
+				contentLen = IOUtils.copyLarge(content, os, new byte[this.copyBufferSize]);
 			}
 		}
 		catch (IOException e) {
@@ -284,7 +287,7 @@ public class DefaultJpaStoreImpl<S, SID extends Serializable>
         try {
             if (resource instanceof WritableResource) {
                 os = ((WritableResource) resource).getOutputStream();
-                readLen = IOUtils.copyLarge(content, os);
+                readLen = IOUtils.copyLarge(content, os, new byte[this.copyBufferSize]);
             }
         }
         catch (IOException e) {

--- a/spring-content-jpa/src/test/java/internal/org/springframework/content/jpa/store/DefaultJpaStoreImplTest.java
+++ b/spring-content-jpa/src/test/java/internal/org/springframework/content/jpa/store/DefaultJpaStoreImplTest.java
@@ -66,7 +66,7 @@ public class DefaultJpaStoreImplTest {
 	{
 		Describe("DefaultJpaStoreImpl", () -> {
 			JustBeforeEach(() -> {
-				store = spy(new DefaultJpaStoreImpl(blobResourceLoader, null));
+				store = spy(new DefaultJpaStoreImpl(blobResourceLoader, null, 8096));
 			});
 
 			Describe("Store", () -> {
@@ -313,7 +313,7 @@ public class DefaultJpaStoreImplTest {
 
         Describe("DefaultJpaStoreImpl jakartaAnnotatedEntity", () -> {
             JustBeforeEach(() -> {
-                store = spy(new DefaultJpaStoreImpl(blobResourceLoader, null));
+                store = spy(new DefaultJpaStoreImpl(blobResourceLoader, null, 8096));
             });
 
             Describe("Store", () -> {


### PR DESCRIPTION
Fixes #1944 