### PR TITLE
Revert "build(deps): bump jakarta.persistence:jakarta.persistence-api from 3.1.0 to 3.2.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ Integrates with Spring Data, Spring Data REST and Apache Solr</description>
         <commons-lang.version>2.6</commons-lang.version>
         <common-logging.version>1.3.2</common-logging.version>
         <commons-text.version>1.12.0</commons-text.version>
-        <jakarta-persistence-api.version>3.2.0</jakarta-persistence-api.version>
+        <jakarta-persistence-api.version>3.1.0</jakarta-persistence-api.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <hibernate-orm.version>6.1.7.Final</hibernate-orm.version>
         <solr-solrj.version>9.6.1</solr-solrj.version>


### PR DESCRIPTION
Spring Boot doesn't support JPA 3.2, see https://github.com/spring-projects/spring-boot/issues/41176 and the discussion in https://github.com/spring-projects/spring-boot/issues/39753

Reverts paulcwarren/spring-content#1959
