### PR TITLE
Wrap all message converters from spring-data-rest with a multipart-supporting message converter

### DIFF
--- a/spring-content-rest/src/main/java/org/springframework/data/rest/extensions/entitycontent/RepositoryEntityMultipartConfiguration.java
+++ b/spring-content-rest/src/main/java/org/springframework/data/rest/extensions/entitycontent/RepositoryEntityMultipartConfiguration.java
@@ -3,7 +3,6 @@ package org.springframework.data.rest.extensions.entitycontent;
 import org.springframework.context.annotation.*;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.core.type.AnnotatedTypeMetadata;
 
 import java.util.List;
 
@@ -15,8 +14,11 @@ public class RepositoryEntityMultipartConfiguration {
     public RepositoryRestConfigurer entityMultipartHttpMessageConverterConfigurer() {
         return new RepositoryRestConfigurer() {
             public void configureHttpMessageConverters(List<HttpMessageConverter<?>> messageConverters) {
-                // Add your custom message converter to the list
-                messageConverters.add(new RepositoryEntityMultipartHttpMessageConverter(messageConverters));
+                var multipartConverters = messageConverters.stream()
+                        .map(RepositoryEntityMultipartHttpMessageConverter::new)
+                        .toList();
+
+                messageConverters.addAll(multipartConverters);
             }
         };
     }


### PR DESCRIPTION
In spring-data-rest 4.4.0, the logic has changed and now
`RepresentationModel`is being passed to `canRead()` instead of
`PersistentEntityResource`.

To support both versions of spring-data-rest for a while, we can wrap all
message converters with one that supports multipart and converts it to
JSON. This also allows users to configure their own specific HttpMessageConverters
and have it automatically work with multipart as well.