### PR TITLE
Fix S3 PartialContentInputStream to be compliant to InputStream specification

### DIFF
--- a/spring-content-encryption/src/main/java/internal/org/springframework/content/fragments/EncryptingContentStoreImpl.java
+++ b/spring-content-encryption/src/main/java/internal/org/springframework/content/fragments/EncryptingContentStoreImpl.java
@@ -329,7 +329,7 @@ public class EncryptingContentStoreImpl<S, SID extends Serializable> implements 
         return r;
     }
 
-    private int getOffset(Resource r, GetResourceParams params) {
+    private long getOffset(Resource r, GetResourceParams params) {
         int offset = 0;
 
         if (r instanceof RangeableResource == false)
@@ -337,18 +337,18 @@ public class EncryptingContentStoreImpl<S, SID extends Serializable> implements 
         if (params.getRange() == null)
             return offset;
 
-        return Integer.parseInt(StringUtils.substringBetween(params.getRange(), "bytes=", "-"));
+        return Long.parseUnsignedLong(StringUtils.substringBetween(params.getRange(), "bytes=", "-"));
     }
 
-    private int getOffset(Resource r, org.springframework.content.commons.store.GetResourceParams params) {
-        int offset = 0;
+    private long getOffset(Resource r, org.springframework.content.commons.store.GetResourceParams params) {
+        long offset = 0;
 
         if (r instanceof RangeableResource == false)
             return offset;
         if (params.getRange() == null)
             return offset;
 
-        return Integer.parseInt(StringUtils.substringBetween(params.getRange(), "bytes=", "-"));
+        return Long.parseUnsignedLong(StringUtils.substringBetween(params.getRange(), "bytes=", "-"));
     }
 
     @Override

--- a/spring-content-encryption/src/main/java/org/springframework/content/encryption/EnvelopeEncryptionService.java
+++ b/spring-content-encryption/src/main/java/org/springframework/content/encryption/EnvelopeEncryptionService.java
@@ -1,6 +1,5 @@
 package org.springframework.content.encryption;
 
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.data.util.Pair;
 import org.springframework.vault.core.VaultOperations;
 import org.springframework.vault.core.VaultTransitOperations;
@@ -11,7 +10,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -91,33 +89,13 @@ public class EnvelopeEncryptionService {
         byte[] iv = new byte[128 / 8];
         System.arraycopy(nonce, 0, iv, 0, nonce.length);
 
-        int AES_BLOCK_SIZE = 16;
-        int blockOffset = offset - (offset % AES_BLOCK_SIZE);
-        final BigInteger ivBI = new BigInteger(1, iv);
-        final BigInteger ivForOffsetBI = ivBI.add(BigInteger.valueOf(blockOffset / AES_BLOCK_SIZE));
-        final byte[] ivForOffsetBA = ivForOffsetBI.toByteArray();
-        final IvParameterSpec ivForOffset;
-        if (ivForOffsetBA.length >= AES_BLOCK_SIZE) {
-            ivForOffset = new IvParameterSpec(ivForOffsetBA, ivForOffsetBA.length - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
-        } else {
-            final byte[] ivForOffsetBASized = new byte[AES_BLOCK_SIZE];
-            System.arraycopy(ivForOffsetBA, 0, ivForOffsetBASized, AES_BLOCK_SIZE - ivForOffsetBA.length, ivForOffsetBA.length);
-            ivForOffset = new IvParameterSpec(ivForOffsetBASized);
-        }
+        cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, new IvParameterSpec(iv));
 
-        cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivForOffset);
 
-        CipherInputStream cis = new CipherInputStream(is, cipher);
+        return new SkippingInputStream(new CipherInputStream(is, cipher)) ;
 
-        InputStream inputStreamToReturn = cis;
-        if (offset == 0) {
-            inputStreamToReturn = new ZeroOffsetSkipInputStream(cis);
-        } else if (offset > 0) {
-            inputStreamToReturn = new OffsetSkipInputStream(cis, offset % AES_BLOCK_SIZE);
-        }
-
-        return inputStreamToReturn;
     }
+
     private SecretKeySpec decryptKey(byte[] encryptedKey, String keyName) {
         VaultTransitOperations transit = vaultOperations.opsForTransit();
         String decryptedBase64Key = transit.decrypt(keyName, new String(encryptedKey));
@@ -148,12 +126,12 @@ public class EnvelopeEncryptionService {
     }
 
     // CipherInputStream skip does not work.  This wraps a cipherinputstream purely to override the skip with a
-    // working version.  Used when backend Store has not already primed the input stream.
-    public class ZeroOffsetSkipInputStream extends FilterInputStream
+    // working version.
+    private static class SkippingInputStream extends FilterInputStream
     {
         private static final int MAX_SKIP_BUFFER_SIZE = 2048;
 
-        protected ZeroOffsetSkipInputStream(InputStream in)
+        protected SkippingInputStream(InputStream in)
         {
             super(in);
         }
@@ -182,42 +160,4 @@ public class EnvelopeEncryptionService {
         }
     }
 
-    // This wraps a cipherinputstream purely to override skip
-    //
-    // Used when a backend store has already satisfied a range request (this service will request a range to the nearest block).
-    // Skips then skips bytes between the beginning of the block and the start actual range that the client requested.
-    public class OffsetSkipInputStream extends FilterInputStream
-    {
-        private static final int MAX_SKIP_BUFFER_SIZE = 2048;
-        private final int offset;
-
-        protected OffsetSkipInputStream(InputStream in, int offset)
-        {
-            super(in);
-            this.offset = offset;
-        }
-
-        public long skip(long n)
-                throws IOException
-        {
-            long remaining = offset;
-            int nr;
-
-            if (n <= 0) {
-                return 0;
-            }
-
-            int size = (int)Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
-            byte[] skipBuffer = new byte[size];
-            while (remaining > 0) {
-                nr = in.read(skipBuffer, 0, (int)Math.min(size, remaining));
-                if (nr < 0) {
-                    break;
-                }
-                remaining -= nr;
-            }
-
-            return n - remaining;
-        }
-    }
 }

--- a/spring-content-encryption/src/main/java/org/springframework/content/encryption/EnvelopeEncryptionService.java
+++ b/spring-content-encryption/src/main/java/org/springframework/content/encryption/EnvelopeEncryptionService.java
@@ -84,7 +84,7 @@ public class EnvelopeEncryptionService {
         return KEY_GENERATOR.generateKey();
     }
 
-    private InputStream decryptInputStream(final SecretKeySpec secretKeySpec, byte[] nonce, int offset, InputStream is) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, IOException, InvalidAlgorithmParameterException {
+    private InputStream decryptInputStream(final SecretKeySpec secretKeySpec, byte[] nonce, long offset, InputStream is) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, IOException, InvalidAlgorithmParameterException {
         Cipher cipher = Cipher.getInstance(transformation);
 
         byte[] iv = new byte[128 / 8];
@@ -124,7 +124,7 @@ public class EnvelopeEncryptionService {
         return key;
     }
 
-    public InputStream decrypt(byte[] ecryptedContext, InputStream is, int offset, String keyName) {
+    public InputStream decrypt(byte[] ecryptedContext, InputStream is, long offset, String keyName) {
 
         byte[] key = new byte[105];
         System.arraycopy(ecryptedContext, 0, key, 0, 105);

--- a/spring-content-encryption/src/test/java/org/springframework/content/encryption/LocalStack.java
+++ b/spring-content-encryption/src/test/java/org/springframework/content/encryption/LocalStack.java
@@ -32,6 +32,7 @@ public class LocalStack extends LocalStackContainer implements Serializable {
     public static S3Client getAmazonS3Client() throws URISyntaxException {
         return S3Client.builder()
                 .endpointOverride(new URI(Singleton.INSTANCE.getEndpointConfiguration(LocalStackContainer.Service.S3).getServiceEndpoint()))
+                .region(Region.US_EAST_1)
                 .credentialsProvider(new CrossAwsCredentialsProvider(Singleton.INSTANCE.getDefaultCredentialsProvider()))
                 .serviceConfiguration((bldr) -> bldr.pathStyleAccessEnabled(true).build())
                 .build();

--- a/spring-content-encryption/src/test/java/org/springframework/content/encryption/s3/EncryptionIT.java
+++ b/spring-content-encryption/src/test/java/org/springframework/content/encryption/s3/EncryptionIT.java
@@ -162,6 +162,19 @@ public class EncryptionIT {
                                     .and().extract().response();
 
                     assertThat(r.asString(), is("ide encryption"));
+
+                    r =
+                            given()
+                                    .header("accept", "text/plain")
+                                    .header("range", "bytes=19-27")
+                                    .get("/files/" + f.getId() + "/content")
+                                    .then()
+                                    .statusCode(HttpStatus.SC_PARTIAL_CONTENT)
+                                    .assertThat()
+                                    .contentType(Matchers.startsWith("text/plain"))
+                                    .and().extract().response();
+
+                    assertThat(r.asString(), is("ncryption"));
                 });
                 Context("when the keyring is rotated", () -> {
                     BeforeEach(() -> {

--- a/spring-content-encryption/src/test/java/org/springframework/content/encryption/s3/EncryptionIT.java
+++ b/spring-content-encryption/src/test/java/org/springframework/content/encryption/s3/EncryptionIT.java
@@ -153,7 +153,7 @@ public class EncryptionIT {
                     MockMvcResponse r =
                             given()
                                     .header("accept", "text/plain")
-                                    .header("range", "bytes=16-27")
+                                    .header("range", "bytes=14-27")
                                     .get("/files/" + f.getId() + "/content")
                                     .then()
                                     .statusCode(HttpStatus.SC_PARTIAL_CONTENT)
@@ -161,7 +161,7 @@ public class EncryptionIT {
                                     .contentType(Matchers.startsWith("text/plain"))
                                     .and().extract().response();
 
-                    assertThat(r.asString(), is("e encryption"));
+                    assertThat(r.asString(), is("ide encryption"));
                 });
                 Context("when the keyring is rotated", () -> {
                     BeforeEach(() -> {

--- a/spring-content-s3/src/main/java/internal/org/springframework/content/s3/io/PartialContentInputStream.java
+++ b/spring-content-s3/src/main/java/internal/org/springframework/content/s3/io/PartialContentInputStream.java
@@ -1,0 +1,187 @@
+package internal.org.springframework.content.s3.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.springframework.util.Assert;
+
+/**
+ * A partial content input stream wrapper around a delegate {@link InputStream}.
+ * <p>
+ * The delegate is expected to be a "prepared" input stream for a certain byte-range of the original resource.
+ * Only bytes inside the byte-range of the original resource can be read successfully,
+ * all bytes outside the available byte-range will return zero-bytes.
+ */
+class PartialContentInputStream extends InputStream {
+
+    private final InputStream delegate;
+    private final long totalLength;
+    private final long rangeStart;
+    private final long rangeEnd;
+    private long currentPosition = 0;
+
+    // As per https://www.rfc-editor.org/rfc/rfc9110.html#field.content-range
+    private static final Pattern CONTENT_RANGE_PATTERN = Pattern.compile("\\Abytes (?<firstPos>[0-9]+)-(?<lastPos>[0-9]+)/(?<completeLength>[0-9]+|\\*)\\Z");
+
+    public static InputStream fromContentRange(InputStream delegate, String contentRange) {
+        Assert.notNull(delegate, "delegate");
+        Assert.notNull(contentRange, "contentRange");
+        var contentRangeMatch = CONTENT_RANGE_PATTERN.matcher(contentRange);
+        if(!contentRangeMatch.matches()) {
+            throw new IllegalArgumentException("Content-Range '%s' is not RFC9110 compliant.".formatted(contentRange));
+        }
+        var rangeStart = Long.parseUnsignedLong(contentRangeMatch.group("firstPos"));
+        // HTTP Content-Range has last byte inclusive; but this object requires an exclusive boundary
+        var rangeEnd = Long.parseUnsignedLong(contentRangeMatch.group("lastPos")) + 1;
+        var completeLengthStr = contentRangeMatch.group("completeLength");
+        var completeLength = Objects.equals(completeLengthStr, "*")?rangeEnd:Long.parseUnsignedLong(completeLengthStr);
+        return new PartialContentInputStream(delegate, completeLength, rangeStart, rangeEnd);
+    }
+
+    public PartialContentInputStream(
+            InputStream delegate,
+            long totalLength,
+            long rangeStart,
+            long rangeEndExclusive
+    ) {
+        this.delegate = delegate;
+        if(totalLength < rangeEndExclusive) {
+            // Total length can not be less than the end of the range
+            // Note that this also covers the case where the total length is unknown
+            totalLength = rangeEndExclusive;
+        }
+        this.totalLength = totalLength;
+        this.rangeStart = rangeStart;
+        this.rangeEnd = rangeEndExclusive;
+    }
+
+    private BlockState blockState(long length) {
+        if(currentPosition + length < 0) { // Sum is negative -> overflow of currentPosition. Reduce n to a more sensible value.
+            length = Long.MAX_VALUE - currentPosition; // maximum value of length (will be MAX_VALUE after adding currentPosition + length)
+        }
+        var startPosition = currentPosition;
+        var endPosition = Math.min(currentPosition + length, totalLength); // We can skip at most to the total length
+        if (endPosition < rangeStart || startPosition >= rangeEnd) {
+            // Our end position is before the start of the range that we're holding
+            // Or our start position is after the end of the range that we're holding
+            // All positions between are outside the range
+            return new BlockState(
+                    false,
+                    startPosition,
+                    endPosition
+            );
+        } else if (startPosition < rangeStart /* implicit by condition above: && endPosition >= rangeStart */) {
+            // We are starting outside the range. Go right up until the start of the range only
+            return new BlockState(
+                    false,
+                    startPosition,
+                    rangeStart
+            );
+        } else {
+            // We are currently inside the range. Go right up until the end of the range at most
+            return new BlockState(
+                    true,
+                    startPosition,
+                    Math.min(endPosition, rangeEnd)
+            );
+        }
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        if (n <= 0) {
+            // Negative number requested; don't skip at all
+            return 0;
+        }
+
+        var startPosition = this.currentPosition;
+        var positionState = blockState(n);
+
+        if(positionState.insideRange()) {
+            // Skip on the delegate stream (however much it wants to skip) and update our current position
+            // We know that the delegate stream can not skip beyond EOF, so no end position check is necessary
+            this.currentPosition += delegate.skip(n);
+        } else {
+            this.currentPosition = positionState.endPosition();
+        }
+
+        return currentPosition - startPosition;
+    }
+
+    @Override
+    public int read()
+            throws IOException {
+        if(currentPosition >= totalLength) {
+            return -1;
+        }
+        var positionState = blockState(1);
+        try {
+            if(positionState.insideRange()) {
+                // Current position is inside the range, read from the delegate stream
+                return delegate.read();
+            }
+            // We are outside the range, return a NUL byte for all data outside the available range
+            return 0;
+        } finally {
+            currentPosition++;
+        }
+    }
+
+    @Override
+    public int read(byte[] buffer, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, buffer.length);
+        if(currentPosition >= totalLength) {
+            return -1;
+        }
+        var positionState = blockState(len);
+        if(positionState.insideRange()) {
+            var readBytes = delegate.read(buffer, off, positionState.intLength());
+            this.currentPosition += readBytes;
+            return readBytes;
+        } else {
+            // Outside of the range; fill the necessary part of the buffer with NUL bytes
+            Arrays.fill(buffer, off, off+positionState.intLength(), (byte)0);
+            this.currentPosition = positionState.endPosition();
+            return positionState.intLength();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "PartialContentInputStream[range=%d-%d; delegate=%s]".formatted(rangeStart, rangeEnd, delegate);
+    }
+
+    @Override
+    public int available() throws IOException {
+        var state = blockState(Integer.MAX_VALUE);
+        if(state.insideRange()) {
+            return delegate.available();
+        } else {
+            return state.intLength();
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException {
+        delegate.close();
+    }
+
+    private record BlockState(
+            boolean insideRange,
+            long startPosition,
+            long endPosition
+    ) {
+
+        public long length() {
+            return endPosition - startPosition;
+        }
+
+        public int intLength() {
+            return (int)Math.min(length(), Integer.MAX_VALUE);
+        }
+
+    }
+}

--- a/spring-content-s3/src/test/java/internal/org/springframework/content/s3/io/PartialContentInputStreamTest.java
+++ b/spring-content-s3/src/test/java/internal/org/springframework/content/s3/io/PartialContentInputStreamTest.java
@@ -1,0 +1,245 @@
+package internal.org.springframework.content.s3.io;
+
+import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.*;
+
+import com.github.paulcwarren.ginkgo4j.Ginkgo4jSpringRunner;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(Ginkgo4jSpringRunner.class)
+public class PartialContentInputStreamTest {
+
+    private static final byte[] FULL_DATA = "This is a test string".getBytes(StandardCharsets.UTF_8);
+    private static final byte NUL = 0;
+
+    private InputStream inputStream;
+
+
+    {
+        Describe("PartialContentInputStream", () -> {
+            Context("with a range from the start", () -> {
+                BeforeEach(() -> {
+                    inputStream = PartialContentInputStream.fromContentRange(
+                            new ByteArrayInputStream(FULL_DATA, 0, 4),
+                            "bytes 0-3/"+FULL_DATA.length // bytes in the range description are *inclusive*
+                    );
+                });
+                AfterEach(() -> {
+                    inputStream.close();
+                });
+                It("reads fully from start to finish", () -> {
+                    var readData = new byte[FULL_DATA.length];
+                    Arrays.fill(readData, (byte)0xba); // Fill array to detect that it is properly filled with NUL bytes by the read function
+                    IOUtils.readFully(inputStream, readData);
+
+                    assertThat(readData[0], is(equalTo(FULL_DATA[0])));
+                    assertThat(readData[1], is(equalTo(FULL_DATA[1])));
+                    assertThat(readData[2], is(equalTo(FULL_DATA[2])));
+                    assertThat(readData[3], is(equalTo(FULL_DATA[3])));
+                    for(int i = 4; i < FULL_DATA.length; i++) {
+                        assertThat(readData[i], is(equalTo(NUL)));
+                    }
+
+                    // Stream is at EOF after reading all the bytes
+                    assertThat(inputStream.read(), is(equalTo(-1)));
+                });
+
+                It("skips bytes into the range", () -> {
+                    inputStream.skipNBytes(2);
+
+                    var readData = new byte[6];
+                    Arrays.fill(readData, (byte)0xba); // Fill array to detect that it is properly filled with NUL bytes by the read function
+                    IOUtils.readFully(inputStream, readData);
+                    assertThat(readData[0], is(equalTo(FULL_DATA[2])));
+                    assertThat(readData[1], is(equalTo(FULL_DATA[3])));
+                    assertThat(readData[2], is(equalTo(NUL)));
+
+                });
+
+                It("skips bytes inside the range", () -> {
+                    assertThat(inputStream.read(), is(equalTo(FULL_DATA[0] & 0xff)));
+                    inputStream.skipNBytes(2); // Bytes 1 & 2 are skipped
+                    assertThat(inputStream.read(), is(equalTo(FULL_DATA[3] & 0xff)));
+                    assertThat(inputStream.read(), is(equalTo(NUL & 0xff)));
+                });
+
+                It("skips bytes out of the range", () -> {
+                    assertThat(inputStream.read(), is(equalTo(FULL_DATA[0] & 0xff)));
+                    inputStream.skipNBytes(FULL_DATA.length - 1); // Skip until past the end of the range; right up until the end of the data
+
+                    assertThat(inputStream.read(), is(equalTo(-1))); // EOF
+                });
+
+                It("skips bytes after the end of the range", () -> {
+                    inputStream.skipNBytes(4); // Skip right up to the end of the range
+
+                    assertThat(inputStream.skip(Long.MAX_VALUE), is(equalTo((long)FULL_DATA.length - 4))); // All the rest of the bytes can be skipped at once
+                });
+
+            });
+            Context("with a range to the end", () -> {
+                BeforeEach(() -> {
+                    inputStream = PartialContentInputStream.fromContentRange(
+                            new ByteArrayInputStream(FULL_DATA, 10, FULL_DATA.length-10),
+                            "bytes 10-"+FULL_DATA.length+"/*"
+                    );
+                });
+                AfterEach(() -> {
+                    inputStream.close();
+                });
+
+                It("reads fully from start to finish", () -> {
+                    var readData = new byte[FULL_DATA.length];
+                    Arrays.fill(readData, (byte)0xba); // Fill array to detect that it is properly filled with NUL bytes by the read function
+                    IOUtils.readFully(inputStream, readData);
+
+                    for(int i = 0; i < 10; i++) {
+                        assertThat(readData[i], is(equalTo(NUL)));
+                    }
+                    for(int i = 10; i < FULL_DATA.length; i++) {
+                        assertThat(readData[i], is(equalTo(FULL_DATA[i])));
+                    }
+                    // Stream is at EOF after reading all the bytes
+                    assertThat(inputStream.read(), is(equalTo(-1)));
+                });
+
+                It("skips bytes before start of the range", () -> {
+                    assertThat(inputStream.skip(5), is(equalTo(5L))); // Can skip bytes before start of range
+
+                    // Check that read data skips the 5 bytes that were skipped
+                    var readData = new byte[FULL_DATA.length-5];
+                    Arrays.fill(readData, (byte)0xba); // Fill array to detect that it is properly filled with NUL bytes by the read function
+                    IOUtils.readFully(inputStream, readData);
+                    assertThat(readData[0], is(equalTo(NUL)));
+                    assertThat(readData[4], is(equalTo(NUL)));
+                    for(int i = 5; i < readData.length; i++) {
+                        assertThat(readData[i], is(equalTo(FULL_DATA[5+i])));
+                    }
+
+                    assertThat(inputStream.read(), is(equalTo(-1))); // EOF
+                });
+
+                It("skips bytes into the range", () -> {
+                    inputStream.skipNBytes(15);
+
+                    var readData = new byte[6];
+                    IOUtils.readFully(inputStream, readData);
+                    for(int i = 0; i < 6; i++) {
+                        assertThat(readData[i], is(equalTo(FULL_DATA[15+i])));
+                    }
+                });
+
+                It("skips bytes inside the range", () -> {
+                    inputStream.skipNBytes(10); // Skip right up to the start of the range
+
+                    assertThat(inputStream.read(), is(equalTo(FULL_DATA[10] & 0xff)));
+                    inputStream.skipNBytes(2); // bytes 11 & 12 are skipped
+                    assertThat(inputStream.read(), is(equalTo(FULL_DATA[13] & 0xff)));
+                });
+
+                It("skips bytes out of the range", () -> {
+                    inputStream.skipNBytes(10); // Skip right up to the start of the range
+                    assertThat(inputStream.read(), is(equalTo(FULL_DATA[10] & 0xff)));
+                    inputStream.skipNBytes(FULL_DATA.length - 11); // Skip until the end of the range
+
+                    assertThat(inputStream.read(), is(equalTo(-1))); // EOF
+                });
+            });
+            Context("with a range in the middle", () -> {
+                BeforeEach(() -> {
+                    inputStream = PartialContentInputStream.fromContentRange(
+                            new ByteArrayInputStream(FULL_DATA, 3, 4),
+                            "bytes 3-6/"+FULL_DATA.length // bytes in the range description are *inclusive*
+                    );
+                });
+                AfterEach(() -> {
+                    inputStream.close();
+                });
+                It("reads fully from start to finish", () -> {
+                    var readData = new byte[FULL_DATA.length];
+                    Arrays.fill(readData, (byte)0xba); // Fill array to detect that it is properly filled with NUL bytes by the read function
+                    IOUtils.readFully(inputStream, readData);
+
+                    for(int i = 0; i < 3; i++) {
+                        assertThat(readData[i], is(equalTo(NUL)));
+                    }
+                    assertThat(readData[3], is(equalTo(FULL_DATA[3])));
+                    assertThat(readData[4], is(equalTo(FULL_DATA[4])));
+                    assertThat(readData[5], is(equalTo(FULL_DATA[5])));
+                    assertThat(readData[6], is(equalTo(FULL_DATA[6])));
+                    for(int i = 7; i < FULL_DATA.length; i++) {
+                        assertThat(readData[i], is(equalTo(NUL)));
+                    }
+
+                    // Stream is at EOF after reading all the bytes
+                    assertThat(inputStream.read(), is(equalTo(-1)));
+                });
+
+                It("skips bytes before start of the range", () -> {
+                    assertThat(inputStream.skip(2), is(equalTo(2L))); // Can skip bytes before start of range
+
+                    // Check that read data skips the 2 bytes that were skipped
+                    var readData = new byte[6];
+                    Arrays.fill(readData, (byte)0xba); // Fill array to detect that it is properly filled with NUL bytes by the read function
+                    IOUtils.readFully(inputStream, readData);
+                    assertThat(readData[0], is(equalTo(NUL)));
+                    assertThat(readData[1], is(equalTo(FULL_DATA[3])));
+                    assertThat(readData[2], is(equalTo(FULL_DATA[4])));
+                    assertThat(readData[3], is(equalTo(FULL_DATA[5])));
+                    assertThat(readData[4], is(equalTo(FULL_DATA[6])));
+                    assertThat(readData[5], is(equalTo(NUL)));
+                });
+
+                It("skips bytes into the range", () -> {
+                    inputStream.skipNBytes(4);
+
+                    var readData = new byte[6];
+                    Arrays.fill(readData, (byte)0xba); // Fill array to detect that it is properly filled with NUL bytes by the read function
+                    IOUtils.readFully(inputStream, readData);
+                    assertThat(readData[0], is(equalTo(FULL_DATA[4])));
+                    assertThat(readData[1], is(equalTo(FULL_DATA[5])));
+                    assertThat(readData[2], is(equalTo(FULL_DATA[6])));
+                    assertThat(readData[3], is(equalTo(NUL)));
+
+                });
+
+                It("skips bytes inside the range", () -> {
+                    inputStream.skipNBytes(3); // Skip right up to the start of the range
+
+                    assertThat(inputStream.read(), is(equalTo(FULL_DATA[3] & 0xff)));
+                    inputStream.skipNBytes(2); // Bytes 4 & 5 are skipped
+                    assertThat(inputStream.read(), is(equalTo(FULL_DATA[6] & 0xff)));
+                    assertThat(inputStream.read(), is(equalTo(NUL & 0xff)));
+                });
+
+                It("skips bytes out of the range", () -> {
+                    inputStream.skipNBytes(3); // Skip right up to the start of the range
+                    assertThat(inputStream.read(), is(equalTo(FULL_DATA[3] & 0xff)));
+                    inputStream.skipNBytes(FULL_DATA.length - 4); // Skip until past the end of the range; right up until the end of the data
+
+                    assertThat(inputStream.read(), is(equalTo(-1))); // EOF
+                });
+
+                It("skips bytes after the end of the range", () -> {
+                    inputStream.skipNBytes(7); // Skip right up to the end of the range
+
+                    assertThat(inputStream.skip(Long.MAX_VALUE), is(equalTo((long)FULL_DATA.length - 7))); // All the rest of the bytes can be skipped at once
+                });
+
+            });
+
+        });
+    }
+
+
+    @Test
+    public void noop() {}
+}

--- a/spring-content-s3/src/test/java/internal/org/springframework/content/s3/it/LocalStack.java
+++ b/spring-content-s3/src/test/java/internal/org/springframework/content/s3/it/LocalStack.java
@@ -8,6 +8,7 @@ import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.Serializable;
@@ -31,6 +32,7 @@ public class LocalStack extends LocalStackContainer implements Serializable {
     public static S3Client getAmazonS3Client() throws URISyntaxException {
         return S3Client.builder()
                 .endpointOverride(new URI(Singleton.INSTANCE.getEndpointConfiguration(LocalStackContainer.Service.S3).getServiceEndpoint()))
+                .region(Region.US_EAST_1) // Set a region, so it does not need to be configured externally
                 .credentialsProvider(new CrossAwsCredentialsProvider(Singleton.INSTANCE.getDefaultCredentialsProvider()))
                 .serviceConfiguration((bldr) -> bldr.pathStyleAccessEnabled(true).build())
                 .build();


### PR DESCRIPTION
The PartialContentInputStream was a minimal implementation that worked
well when used directly with the spring byte-range support.

However, using the InputStream variant in any other place (like wrapping it for decryption),
the minimal implementation breaks down, requiring workarounds when
handling the encryption.
Using an implementation that is fully compliant with the InputStream
specifications makes implementation of a wrapping InputStream easier,
as no special provisions need to be made for a read method that
immediately reads the byte-range (instead of empty space before the start of the byte-range)