### PR TITLE
fix(gcp): avoid circular references in GCPStorageConfiguration (from cjnickel)

### DIFF
--- a/spring-content-gcs/src/main/java/internal/org/springframework/content/gcs/config/GCPStorageConfiguration.java
+++ b/spring-content-gcs/src/main/java/internal/org/springframework/content/gcs/config/GCPStorageConfiguration.java
@@ -32,9 +32,10 @@ public class GCPStorageConfiguration implements InitializingBean {
 	@Value("${spring.content.gcp.storage.bucket:#{environment.GCP_STORAGE_BUCKET}}")
 	private String bucket;
 
+	private PlacementService conversion = new PlacementServiceImpl();
+
 	@Bean
 	public PlacementService gcpStoragePlacementService() {
-		PlacementService conversion = new PlacementServiceImpl();
 		return conversion;
 	}
 
@@ -82,7 +83,7 @@ public class GCPStorageConfiguration implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		addDefaultConverters(gcpStoragePlacementService(), bucket);
-		addConverters(gcpStoragePlacementService());
+		addDefaultConverters(conversion, bucket);
+		addConverters(conversion);
 	}
 }


### PR DESCRIPTION
The `GCPStorageConfiguration` may lead to exceptions due to circular references caused by the provider for the `PlacementService`.

Creating the instance during object creation (like in the `S3StoreConfiguration`) avoids this problem.

Closes #2335

Supercedes: #2336 